### PR TITLE
Support building with GHC 9.0

### DIFF
--- a/.github/workflows/ci-matrix.yml
+++ b/.github/workflows/ci-matrix.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-haskell@v1
+    - uses: haskell/actions/setup@v1
       id: setup-haskell-cabal
       name: Setup Haskell
       with:

--- a/.github/workflows/ci-matrix.yml
+++ b/.github/workflows/ci-matrix.yml
@@ -18,14 +18,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ['8.6.5', '8.8.4', '8.10.2']
-        cabal: ['3.2.0.0']
+        ghc: ['8.8.4', '8.10.7', '9.0.2']
+        cabal: ['3.6.2.0']
         os: [ubuntu-latest, macOS-latest]
         exclude:
           - os: macOS-latest
-            ghc: 8.6.5
-          - os: macOS-latest
             ghc: 8.8.4
+          - os: macOS-latest
+            ghc: 8.10.7
 
     name: GHC ${{ matrix.ghc }} on ${{ matrix.os }} portable-executable
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+/cabal.project
+
+# From https://github.com/github/gitignore/blob/master/Haskell.gitignore
+dist
+dist-*
+cabal-dev
+*.o
+*.hi
+*.hie
+*.chi
+*.chs.h
+*.dyn_o
+*.dyn_hi
+.hpc
+.hsenv
+.cabal-sandbox/
+cabal.sandbox.config
+*.prof
+*.aux
+*.hp
+*.eventlog
+.stack-work/
+cabal.project.local
+cabal.project.local~
+.HTF/
+.ghc.environment.*

--- a/pe-parser/pe-parser.cabal
+++ b/pe-parser/pe-parser.cabal
@@ -54,8 +54,8 @@ executable readpe
                        parameterized-utils,
                        prettyprinter,
                        optparse-applicative
-                       
-                           
+
+
 test-suite doctests
   type: exitcode-stdio-1.0
   default-language: Haskell2010
@@ -63,7 +63,7 @@ test-suite doctests
   main-is:        Main.hs
   ghc-options:    -Wall -Wcompat -threaded
   build-depends:  base,
-                  doctest >= 0.10 && < 0.18,
+                  doctest >= 0.10 && < 0.21,
                   -- Dependencies required by the doctest examples
                   --
                   -- We need to specify these here, otherwise the doctests might get built before

--- a/pe-parser/src/PE/Parser/ExceptionTable.hs
+++ b/pe-parser/src/PE/Parser/ExceptionTable.hs
@@ -112,10 +112,10 @@ instance PC.TestEquality ExceptionTableRepr where
 instance PC.ShowF ExceptionTableRepr where
   showsPrecF = $(PTG.structuralShowsPrec [t|ExceptionTableRepr|])
 
-$(return [])
-
 instance Show (ExceptionTableRepr format) where
   show = PC.showF
+
+$(return [])
 
 -- | Map the type-level Exception Table specifier to its corresponding value type
 type family ExceptionTableEntry format where


### PR DESCRIPTION
This contains a couple of fixes needed to make `pe-parser` compile with
GHC 9.0:

* GHC's constraint solver now solves constraints in each top-level group
  sooner (see
  [here](https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.0?version_id=5fcd0a50e0872efb3c38a32db140506da8310d87#the-order-of-th-splices-is-more-important)).
  This affects `PE.Parser.ExceptionTable`, as it separates top-level groups with
  `$(return [])` Template Haskell splices. The previous locations of these
  splices made it so that the TH-generated instances in that package were not
  available to any code before the splice, resulting in type errors when
  compiled with GHC 9.0.

  To overcome this, I moved the location of the `Show` instance for
  `ExceptionTableRepr` to be in the same top-level group as the `ShowF`
  instance.
* The upper version bounds on `doctest` were relaxed to allow building with
  GHC 9.0.